### PR TITLE
Link to repo via `repository` instead of `homepage` in `Cargo.toml`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.0.3"
 edition = "2021"
 description = "Explicitly types your generics"
 license = "MIT OR Apache-2.0"
-homepage = "https://github.com/bincode-org/unty"
+repository = "https://github.com/bincode-org/unty"
 authors = ["Victor Koenders <bincode@trang.ar>"]
 rust-version = "1.56.1"


### PR DESCRIPTION
This makes it easier to find the link when quickly scanning through the docs.rs info or even for automated scanners.